### PR TITLE
Update comps.html

### DIFF
--- a/pcprog/comps.html
+++ b/pcprog/comps.html
@@ -68,7 +68,7 @@
 	      <td>Easy - Hard</td>
 	      <td>Team</td>
 	      <td>Online</td>
-	      <td>September 28 - October 12, 2018</td>
+	      <td>Spring 2021</td>
 	      <td>Cash!</td>
 	  </tr>
 	  <tr>
@@ -77,7 +77,7 @@
 	    <td>Medium - Hard</td>
 	    <td>Individual</td>
 	    <td>Online</td>
-	    <td>December 2018 - March 2019</td>
+	    <td>December, 2020 - March, 2021</td>
 	    <td>No</td>
 	  </tr>
 	  <tr>
@@ -85,8 +85,8 @@
 	    <td>No</td>
 	    <td>Easy - Medium</td>
 	    <td>Team</td>
-	    <td>Asheville</td>
-	    <td>April, 2019</td>
+	    <td>Previously in-person</td>
+	    <td>April, 2021</td>
 	    <td>Yes</td>
 	  </tr>
 	  <tr>
@@ -94,8 +94,8 @@
 	    <td>Yes</td>
 	    <td>Easy - Medium</td>
 	    <td>Team</td>
-	    <td>Charleston</td>
-	    <td>February 22, 2019</td>
+	    <td>Previously in-person</td>
+	    <td>February, 2021</td>
 	    <td>Yes</td>
 	  </tr>
 	  <tr>
@@ -103,8 +103,8 @@
 	    <td>No</td>
 	    <td>Easy - Hard</td>
 	    <td>Team</td>
-	    <td>Charlottesville</td>
-	    <td>March or April 2019</td>
+	    <td>Previously in-person</td>
+	    <td>TBD</td>
 	    <td>Yes</td>
 	  </tr>
 	  <tr>
@@ -113,16 +113,7 @@
 	    <td>Medium - Hard</td>
 	    <td>Team</td>
 	    <td>Online</td>
-	    <td>December, 2018</td>
-	    <td>Yes</td>
-	  </tr>
-	  <tr>
-	    <td>Google Code-In</td>
-	    <td>Yes</td>
-	    <td>Easy - Hard</td>
-	    <td>Individual</td>
-	    <td>Online</td>
-	    <td>December, 2018 - January, 2019</td>
+	    <td>December, 2020</td>
 	    <td>Yes</td>
 	  </tr>
 	  <tr>
@@ -131,7 +122,7 @@
 	    <td>Easy - Hard</td>
 	    <td>Individual</td>
 	    <td>Online</td>
-	    <td>March 2019</td>
+	    <td>April 2021</td>
 	    <td>Cash!</td>
 	  </tr>
 	  <tr>
@@ -139,8 +130,8 @@
 	    <td>Yes</td>
 	    <td>Easy - Medium</td>
 	    <td>Team</td>
-	    <td>Cary</td>
-	    <td>2019</td>
+	    <td>TBD</td>
+	    <td>2020 - 2021</td>
 	    <td>Yes</td>
 	</table>
       </div>


### PR DESCRIPTION
Adjusted dates for competitions that provided updates (picoCTF, Asheville), estimated dates for comps with consistent schedules, location adjusted for comps that haven't been confirmed to be in-person again (looking for a better way to handle this), removed Google Code-in since it will no longer continue (R.I.P.)